### PR TITLE
go: Update Go version to 1.17

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,9 +1,17 @@
 module github.com/cncf/xds/go
 
-go 1.11
+go 1.17
 
 require (
 	github.com/envoyproxy/protoc-gen-validate v0.1.0
-	github.com/golang/protobuf v1.3.2
+	github.com/golang/protobuf v1.5.0
 	google.golang.org/grpc v1.25.1
+	google.golang.org/protobuf v1.27.1
+)
+
+require (
+	golang.org/x/net v0.0.0-20190311183353-d8887717615a // indirect
+	golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a // indirect
+	golang.org/x/text v0.3.0 // indirect
+	google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 // indirect
 )


### PR DESCRIPTION
- Just execute `go mod tidy -go=1.17` under the `go` directory.
    - Go versions older than 1.16 are not supported version.