### PR TITLE
regex: extent regex interface

### DIFF
--- a/xds/type/matcher/v3/regex.proto
+++ b/xds/type/matcher/v3/regex.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package xds.type.matcher.v3;
 
+import "google/protobuf/any.proto";
+
 import "validate/validate.proto";
 
 option java_package = "com.github.xds.type.matcher.v3";
@@ -33,11 +35,22 @@ message RegexMatcher {
   // program size exceeds the warn level threshold.
   message GoogleRE2 {}
 
+  message RegexEngine {
+    // The name of the engine.
+    string name = 1 [(validate.rules).string = {min_bytes: 1}];
+
+    // The typed config for the engine.
+    google.protobuf.Any typed_config = 2 [(validate.rules).any = {required: true}];
+  }
+
   oneof engine_type {
     option (validate.required) = true;
 
     // Google's RE2 regex engine.
-    GoogleRE2 google_re2 = 1 [ (validate.rules).message = {required : true} ];
+    GoogleRE2 google_re2 = 1;
+
+    // Typed regex engine.
+    RegexEngine engine = 3;
   }
 
   // The regex match string. The string must be supported by the configured


### PR DESCRIPTION
Signed-off-by: Xie Zhihao <zhihao.xie@intel.com>

Currently, Google RE2 is the only supported engine in Envoy, and to extent the xDS regex API, we can support other regex engines in the future. In the Envoy's implementation, we would introduce compiled matcher factory which is responsible for generate compiled matcher from typed config. This PR is related to envoyproxy/envoy#19168.