### PR TITLE
Migrate from github.com/golang/protobuf to google.golang.org/protobuf

### DIFF
--- a/bazel/api_build_system.bzl
+++ b/bazel/api_build_system.bzl
@@ -117,14 +117,13 @@ def xds_proto_package(
         visibility = ["//visibility:public"],
         deps = depset([_go_proto_mapping(dep) for dep in deps] + [
             "@com_envoyproxy_protoc_gen_validate//validate:go_default_library",
-            "@com_github_golang_protobuf//ptypes:go_default_library_gen",
             "@go_googleapis//google/api:annotations_go_proto",
             "@go_googleapis//google/rpc:status_go_proto",
-            "@io_bazel_rules_go//proto/wkt:any_go_proto",
-            "@io_bazel_rules_go//proto/wkt:duration_go_proto",
-            "@io_bazel_rules_go//proto/wkt:struct_go_proto",
-            "@io_bazel_rules_go//proto/wkt:timestamp_go_proto",
-            "@io_bazel_rules_go//proto/wkt:wrappers_go_proto",
+            "@org_golang_google_protobuf//types/known/anypb:go_default_library",
+            "@org_golang_google_protobuf//types/known/durationpb:go_default_library",
+            "@org_golang_google_protobuf//types/known/structpb:go_default_library",
+            "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
+            "@org_golang_google_protobuf//types/known/wrapperspb:go_default_library",
         ]).to_list(),
     )
 

--- a/go/go.mod
+++ b/go/go.mod
@@ -4,13 +4,13 @@ go 1.19
 
 require (
 	github.com/envoyproxy/protoc-gen-validate v1.0.4
-	github.com/golang/protobuf v1.5.3
 	google.golang.org/genproto/googleapis/api v0.0.0-20230822172742-b8732ec3820d
 	google.golang.org/grpc v1.59.0
 	google.golang.org/protobuf v1.32.0
 )
 
 require (
+	github.com/golang/protobuf v1.5.3 // indirect
 	golang.org/x/net v0.20.0 // indirect
 	golang.org/x/sys v0.16.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/go/udpa/service/orca/v1/orca.pb.go
+++ b/go/udpa/service/orca/v1/orca.pb.go
@@ -9,12 +9,12 @@ package v1
 import (
 	context "context"
 	v1 "github.com/cncf/xds/go/udpa/data/orca/v1"
-	duration "github.com/golang/protobuf/ptypes/duration"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	reflect "reflect"
 	sync "sync"
 )
@@ -31,8 +31,8 @@ type OrcaLoadReportRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	ReportInterval   *duration.Duration `protobuf:"bytes,1,opt,name=report_interval,json=reportInterval,proto3" json:"report_interval,omitempty"`
-	RequestCostNames []string           `protobuf:"bytes,2,rep,name=request_cost_names,json=requestCostNames,proto3" json:"request_cost_names,omitempty"`
+	ReportInterval   *durationpb.Duration `protobuf:"bytes,1,opt,name=report_interval,json=reportInterval,proto3" json:"report_interval,omitempty"`
+	RequestCostNames []string             `protobuf:"bytes,2,rep,name=request_cost_names,json=requestCostNames,proto3" json:"request_cost_names,omitempty"`
 }
 
 func (x *OrcaLoadReportRequest) Reset() {
@@ -67,7 +67,7 @@ func (*OrcaLoadReportRequest) Descriptor() ([]byte, []int) {
 	return file_udpa_service_orca_v1_orca_proto_rawDescGZIP(), []int{0}
 }
 
-func (x *OrcaLoadReportRequest) GetReportInterval() *duration.Duration {
+func (x *OrcaLoadReportRequest) GetReportInterval() *durationpb.Duration {
 	if x != nil {
 		return x.ReportInterval
 	}
@@ -132,7 +132,7 @@ func file_udpa_service_orca_v1_orca_proto_rawDescGZIP() []byte {
 var file_udpa_service_orca_v1_orca_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
 var file_udpa_service_orca_v1_orca_proto_goTypes = []interface{}{
 	(*OrcaLoadReportRequest)(nil), // 0: udpa.service.orca.v1.OrcaLoadReportRequest
-	(*duration.Duration)(nil),     // 1: google.protobuf.Duration
+	(*durationpb.Duration)(nil),   // 1: google.protobuf.Duration
 	(*v1.OrcaLoadReport)(nil),     // 2: udpa.data.orca.v1.OrcaLoadReport
 }
 var file_udpa_service_orca_v1_orca_proto_depIdxs = []int32{

--- a/go/udpa/type/v1/typed_struct.pb.go
+++ b/go/udpa/type/v1/typed_struct.pb.go
@@ -7,9 +7,9 @@
 package v1
 
 import (
-	_struct "github.com/golang/protobuf/ptypes/struct"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	structpb "google.golang.org/protobuf/types/known/structpb"
 	reflect "reflect"
 	sync "sync"
 )
@@ -26,8 +26,8 @@ type TypedStruct struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	TypeUrl string          `protobuf:"bytes,1,opt,name=type_url,json=typeUrl,proto3" json:"type_url,omitempty"`
-	Value   *_struct.Struct `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
+	TypeUrl string           `protobuf:"bytes,1,opt,name=type_url,json=typeUrl,proto3" json:"type_url,omitempty"`
+	Value   *structpb.Struct `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
 }
 
 func (x *TypedStruct) Reset() {
@@ -69,7 +69,7 @@ func (x *TypedStruct) GetTypeUrl() string {
 	return ""
 }
 
-func (x *TypedStruct) GetValue() *_struct.Struct {
+func (x *TypedStruct) GetValue() *structpb.Struct {
 	if x != nil {
 		return x.Value
 	}
@@ -112,8 +112,8 @@ func file_udpa_type_v1_typed_struct_proto_rawDescGZIP() []byte {
 
 var file_udpa_type_v1_typed_struct_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
 var file_udpa_type_v1_typed_struct_proto_goTypes = []interface{}{
-	(*TypedStruct)(nil),    // 0: udpa.type.v1.TypedStruct
-	(*_struct.Struct)(nil), // 1: google.protobuf.Struct
+	(*TypedStruct)(nil),     // 0: udpa.type.v1.TypedStruct
+	(*structpb.Struct)(nil), // 1: google.protobuf.Struct
 }
 var file_udpa_type_v1_typed_struct_proto_depIdxs = []int32{
 	1, // 0: udpa.type.v1.TypedStruct.value:type_name -> google.protobuf.Struct

--- a/go/xds/core/v3/cidr.pb.go
+++ b/go/xds/core/v3/cidr.pb.go
@@ -9,9 +9,9 @@ package v3
 import (
 	_ "github.com/cncf/xds/go/xds/annotations/v3"
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
-	wrappers "github.com/golang/protobuf/ptypes/wrappers"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
 	reflect "reflect"
 	sync "sync"
 )
@@ -28,8 +28,8 @@ type CidrRange struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	AddressPrefix string                `protobuf:"bytes,1,opt,name=address_prefix,json=addressPrefix,proto3" json:"address_prefix,omitempty"`
-	PrefixLen     *wrappers.UInt32Value `protobuf:"bytes,2,opt,name=prefix_len,json=prefixLen,proto3" json:"prefix_len,omitempty"`
+	AddressPrefix string                  `protobuf:"bytes,1,opt,name=address_prefix,json=addressPrefix,proto3" json:"address_prefix,omitempty"`
+	PrefixLen     *wrapperspb.UInt32Value `protobuf:"bytes,2,opt,name=prefix_len,json=prefixLen,proto3" json:"prefix_len,omitempty"`
 }
 
 func (x *CidrRange) Reset() {
@@ -71,7 +71,7 @@ func (x *CidrRange) GetAddressPrefix() string {
 	return ""
 }
 
-func (x *CidrRange) GetPrefixLen() *wrappers.UInt32Value {
+func (x *CidrRange) GetPrefixLen() *wrapperspb.UInt32Value {
 	if x != nil {
 		return x.PrefixLen
 	}
@@ -120,8 +120,8 @@ func file_xds_core_v3_cidr_proto_rawDescGZIP() []byte {
 
 var file_xds_core_v3_cidr_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
 var file_xds_core_v3_cidr_proto_goTypes = []interface{}{
-	(*CidrRange)(nil),            // 0: xds.core.v3.CidrRange
-	(*wrappers.UInt32Value)(nil), // 1: google.protobuf.UInt32Value
+	(*CidrRange)(nil),              // 0: xds.core.v3.CidrRange
+	(*wrapperspb.UInt32Value)(nil), // 1: google.protobuf.UInt32Value
 }
 var file_xds_core_v3_cidr_proto_depIdxs = []int32{
 	1, // 0: xds.core.v3.CidrRange.prefix_len:type_name -> google.protobuf.UInt32Value

--- a/go/xds/core/v3/collection_entry.pb.go
+++ b/go/xds/core/v3/collection_entry.pb.go
@@ -9,9 +9,9 @@ package v3
 import (
 	_ "github.com/cncf/xds/go/xds/annotations/v3"
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
-	any1 "github.com/golang/protobuf/ptypes/any"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	anypb "google.golang.org/protobuf/types/known/anypb"
 	reflect "reflect"
 	sync "sync"
 )
@@ -109,9 +109,9 @@ type CollectionEntry_InlineEntry struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Name     string    `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Version  string    `protobuf:"bytes,2,opt,name=version,proto3" json:"version,omitempty"`
-	Resource *any1.Any `protobuf:"bytes,3,opt,name=resource,proto3" json:"resource,omitempty"`
+	Name     string     `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Version  string     `protobuf:"bytes,2,opt,name=version,proto3" json:"version,omitempty"`
+	Resource *anypb.Any `protobuf:"bytes,3,opt,name=resource,proto3" json:"resource,omitempty"`
 }
 
 func (x *CollectionEntry_InlineEntry) Reset() {
@@ -160,7 +160,7 @@ func (x *CollectionEntry_InlineEntry) GetVersion() string {
 	return ""
 }
 
-func (x *CollectionEntry_InlineEntry) GetResource() *any1.Any {
+func (x *CollectionEntry_InlineEntry) GetResource() *anypb.Any {
 	if x != nil {
 		return x.Resource
 	}
@@ -227,7 +227,7 @@ var file_xds_core_v3_collection_entry_proto_goTypes = []interface{}{
 	(*CollectionEntry)(nil),             // 0: xds.core.v3.CollectionEntry
 	(*CollectionEntry_InlineEntry)(nil), // 1: xds.core.v3.CollectionEntry.InlineEntry
 	(*ResourceLocator)(nil),             // 2: xds.core.v3.ResourceLocator
-	(*any1.Any)(nil),                    // 3: google.protobuf.Any
+	(*anypb.Any)(nil),                   // 3: google.protobuf.Any
 }
 var file_xds_core_v3_collection_entry_proto_depIdxs = []int32{
 	2, // 0: xds.core.v3.CollectionEntry.locator:type_name -> xds.core.v3.ResourceLocator

--- a/go/xds/core/v3/extension.pb.go
+++ b/go/xds/core/v3/extension.pb.go
@@ -8,9 +8,9 @@ package v3
 
 import (
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
-	any1 "github.com/golang/protobuf/ptypes/any"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	anypb "google.golang.org/protobuf/types/known/anypb"
 	reflect "reflect"
 	sync "sync"
 )
@@ -27,8 +27,8 @@ type TypedExtensionConfig struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Name        string    `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	TypedConfig *any1.Any `protobuf:"bytes,2,opt,name=typed_config,json=typedConfig,proto3" json:"typed_config,omitempty"`
+	Name        string     `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	TypedConfig *anypb.Any `protobuf:"bytes,2,opt,name=typed_config,json=typedConfig,proto3" json:"typed_config,omitempty"`
 }
 
 func (x *TypedExtensionConfig) Reset() {
@@ -70,7 +70,7 @@ func (x *TypedExtensionConfig) GetName() string {
 	return ""
 }
 
-func (x *TypedExtensionConfig) GetTypedConfig() *any1.Any {
+func (x *TypedExtensionConfig) GetTypedConfig() *anypb.Any {
 	if x != nil {
 		return x.TypedConfig
 	}
@@ -116,7 +116,7 @@ func file_xds_core_v3_extension_proto_rawDescGZIP() []byte {
 var file_xds_core_v3_extension_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
 var file_xds_core_v3_extension_proto_goTypes = []interface{}{
 	(*TypedExtensionConfig)(nil), // 0: xds.core.v3.TypedExtensionConfig
-	(*any1.Any)(nil),             // 1: google.protobuf.Any
+	(*anypb.Any)(nil),            // 1: google.protobuf.Any
 }
 var file_xds_core_v3_extension_proto_depIdxs = []int32{
 	1, // 0: xds.core.v3.TypedExtensionConfig.typed_config:type_name -> google.protobuf.Any

--- a/go/xds/core/v3/resource.pb.go
+++ b/go/xds/core/v3/resource.pb.go
@@ -8,9 +8,9 @@ package v3
 
 import (
 	_ "github.com/cncf/xds/go/xds/annotations/v3"
-	any1 "github.com/golang/protobuf/ptypes/any"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	anypb "google.golang.org/protobuf/types/known/anypb"
 	reflect "reflect"
 	sync "sync"
 )
@@ -29,7 +29,7 @@ type Resource struct {
 
 	Name     *ResourceName `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	Version  string        `protobuf:"bytes,2,opt,name=version,proto3" json:"version,omitempty"`
-	Resource *any1.Any     `protobuf:"bytes,3,opt,name=resource,proto3" json:"resource,omitempty"`
+	Resource *anypb.Any    `protobuf:"bytes,3,opt,name=resource,proto3" json:"resource,omitempty"`
 }
 
 func (x *Resource) Reset() {
@@ -78,7 +78,7 @@ func (x *Resource) GetVersion() string {
 	return ""
 }
 
-func (x *Resource) GetResource() *any1.Any {
+func (x *Resource) GetResource() *anypb.Any {
 	if x != nil {
 		return x.Resource
 	}
@@ -129,7 +129,7 @@ var file_xds_core_v3_resource_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
 var file_xds_core_v3_resource_proto_goTypes = []interface{}{
 	(*Resource)(nil),     // 0: xds.core.v3.Resource
 	(*ResourceName)(nil), // 1: xds.core.v3.ResourceName
-	(*any1.Any)(nil),     // 2: google.protobuf.Any
+	(*anypb.Any)(nil),    // 2: google.protobuf.Any
 }
 var file_xds_core_v3_resource_proto_depIdxs = []int32{
 	1, // 0: xds.core.v3.Resource.name:type_name -> xds.core.v3.ResourceName

--- a/go/xds/service/orca/v3/orca.pb.go
+++ b/go/xds/service/orca/v3/orca.pb.go
@@ -9,12 +9,12 @@ package v3
 import (
 	context "context"
 	v3 "github.com/cncf/xds/go/xds/data/orca/v3"
-	duration "github.com/golang/protobuf/ptypes/duration"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	reflect "reflect"
 	sync "sync"
 )
@@ -31,8 +31,8 @@ type OrcaLoadReportRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	ReportInterval   *duration.Duration `protobuf:"bytes,1,opt,name=report_interval,json=reportInterval,proto3" json:"report_interval,omitempty"`
-	RequestCostNames []string           `protobuf:"bytes,2,rep,name=request_cost_names,json=requestCostNames,proto3" json:"request_cost_names,omitempty"`
+	ReportInterval   *durationpb.Duration `protobuf:"bytes,1,opt,name=report_interval,json=reportInterval,proto3" json:"report_interval,omitempty"`
+	RequestCostNames []string             `protobuf:"bytes,2,rep,name=request_cost_names,json=requestCostNames,proto3" json:"request_cost_names,omitempty"`
 }
 
 func (x *OrcaLoadReportRequest) Reset() {
@@ -67,7 +67,7 @@ func (*OrcaLoadReportRequest) Descriptor() ([]byte, []int) {
 	return file_xds_service_orca_v3_orca_proto_rawDescGZIP(), []int{0}
 }
 
-func (x *OrcaLoadReportRequest) GetReportInterval() *duration.Duration {
+func (x *OrcaLoadReportRequest) GetReportInterval() *durationpb.Duration {
 	if x != nil {
 		return x.ReportInterval
 	}
@@ -132,7 +132,7 @@ func file_xds_service_orca_v3_orca_proto_rawDescGZIP() []byte {
 var file_xds_service_orca_v3_orca_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
 var file_xds_service_orca_v3_orca_proto_goTypes = []interface{}{
 	(*OrcaLoadReportRequest)(nil), // 0: xds.service.orca.v3.OrcaLoadReportRequest
-	(*duration.Duration)(nil),     // 1: google.protobuf.Duration
+	(*durationpb.Duration)(nil),   // 1: google.protobuf.Duration
 	(*v3.OrcaLoadReport)(nil),     // 2: xds.data.orca.v3.OrcaLoadReport
 }
 var file_xds_service_orca_v3_orca_proto_depIdxs = []int32{

--- a/go/xds/type/v3/cel.pb.go
+++ b/go/xds/type/v3/cel.pb.go
@@ -9,10 +9,10 @@ package v3
 import (
 	_ "github.com/cncf/xds/go/xds/annotations/v3"
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
-	wrappers "github.com/golang/protobuf/ptypes/wrappers"
 	v1alpha1 "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
 	reflect "reflect"
 	sync "sync"
 )
@@ -110,8 +110,8 @@ type CelExtractString struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	ExprExtract  *CelExpression        `protobuf:"bytes,1,opt,name=expr_extract,json=exprExtract,proto3" json:"expr_extract,omitempty"`
-	DefaultValue *wrappers.StringValue `protobuf:"bytes,2,opt,name=default_value,json=defaultValue,proto3" json:"default_value,omitempty"`
+	ExprExtract  *CelExpression          `protobuf:"bytes,1,opt,name=expr_extract,json=exprExtract,proto3" json:"expr_extract,omitempty"`
+	DefaultValue *wrapperspb.StringValue `protobuf:"bytes,2,opt,name=default_value,json=defaultValue,proto3" json:"default_value,omitempty"`
 }
 
 func (x *CelExtractString) Reset() {
@@ -153,7 +153,7 @@ func (x *CelExtractString) GetExprExtract() *CelExpression {
 	return nil
 }
 
-func (x *CelExtractString) GetDefaultValue() *wrappers.StringValue {
+func (x *CelExtractString) GetDefaultValue() *wrapperspb.StringValue {
 	if x != nil {
 		return x.DefaultValue
 	}
@@ -220,11 +220,11 @@ func file_xds_type_v3_cel_proto_rawDescGZIP() []byte {
 
 var file_xds_type_v3_cel_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
 var file_xds_type_v3_cel_proto_goTypes = []interface{}{
-	(*CelExpression)(nil),        // 0: xds.type.v3.CelExpression
-	(*CelExtractString)(nil),     // 1: xds.type.v3.CelExtractString
-	(*v1alpha1.ParsedExpr)(nil),  // 2: google.api.expr.v1alpha1.ParsedExpr
-	(*v1alpha1.CheckedExpr)(nil), // 3: google.api.expr.v1alpha1.CheckedExpr
-	(*wrappers.StringValue)(nil), // 4: google.protobuf.StringValue
+	(*CelExpression)(nil),          // 0: xds.type.v3.CelExpression
+	(*CelExtractString)(nil),       // 1: xds.type.v3.CelExtractString
+	(*v1alpha1.ParsedExpr)(nil),    // 2: google.api.expr.v1alpha1.ParsedExpr
+	(*v1alpha1.CheckedExpr)(nil),   // 3: google.api.expr.v1alpha1.CheckedExpr
+	(*wrapperspb.StringValue)(nil), // 4: google.protobuf.StringValue
 }
 var file_xds_type_v3_cel_proto_depIdxs = []int32{
 	2, // 0: xds.type.v3.CelExpression.parsed_expr:type_name -> google.api.expr.v1alpha1.ParsedExpr

--- a/go/xds/type/v3/typed_struct.pb.go
+++ b/go/xds/type/v3/typed_struct.pb.go
@@ -7,9 +7,9 @@
 package v3
 
 import (
-	_struct "github.com/golang/protobuf/ptypes/struct"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	structpb "google.golang.org/protobuf/types/known/structpb"
 	reflect "reflect"
 	sync "sync"
 )
@@ -26,8 +26,8 @@ type TypedStruct struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	TypeUrl string          `protobuf:"bytes,1,opt,name=type_url,json=typeUrl,proto3" json:"type_url,omitempty"`
-	Value   *_struct.Struct `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
+	TypeUrl string           `protobuf:"bytes,1,opt,name=type_url,json=typeUrl,proto3" json:"type_url,omitempty"`
+	Value   *structpb.Struct `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
 }
 
 func (x *TypedStruct) Reset() {
@@ -69,7 +69,7 @@ func (x *TypedStruct) GetTypeUrl() string {
 	return ""
 }
 
-func (x *TypedStruct) GetValue() *_struct.Struct {
+func (x *TypedStruct) GetValue() *structpb.Struct {
 	if x != nil {
 		return x.Value
 	}
@@ -111,8 +111,8 @@ func file_xds_type_v3_typed_struct_proto_rawDescGZIP() []byte {
 
 var file_xds_type_v3_typed_struct_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
 var file_xds_type_v3_typed_struct_proto_goTypes = []interface{}{
-	(*TypedStruct)(nil),    // 0: xds.type.v3.TypedStruct
-	(*_struct.Struct)(nil), // 1: google.protobuf.Struct
+	(*TypedStruct)(nil),     // 0: xds.type.v3.TypedStruct
+	(*structpb.Struct)(nil), // 1: google.protobuf.Struct
 }
 var file_xds_type_v3_typed_struct_proto_depIdxs = []int32{
 	1, // 0: xds.type.v3.TypedStruct.value:type_name -> google.protobuf.Struct


### PR DESCRIPTION
`github.com/golang/protobuf` has been superseded by `google.golang.org/protobuf`

This migrates old protobuf leftovers to new version of protobuf