### PR TITLE
pgv_plugin_go : Use protoc_gen_validate instead of xds

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -1,12 +1,1 @@
-load("@io_bazel_rules_go//proto:compiler.bzl", "go_proto_compiler")
-
 licenses(["notice"])  # Apache 2
-
-go_proto_compiler(
-    name = "pgv_plugin_go",
-    options = ["lang=go"],
-    plugin = "@com_envoyproxy_protoc_gen_validate//:protoc-gen-validate",
-    suffix = ".pb.validate.go",
-    valid_archive = False,
-    visibility = ["//visibility:public"],
-)

--- a/bazel/api_build_system.bzl
+++ b/bazel/api_build_system.bzl
@@ -102,9 +102,9 @@ def xds_proto_package(
         has_services = has_services,
     )
 
-    compilers = ["@io_bazel_rules_go//proto:go_proto", "//bazel:pgv_plugin_go"]
+    compilers = ["@io_bazel_rules_go//proto:go_proto", "@com_envoyproxy_protoc_gen_validate//bazel/go:pgv_plugin_go"]
     if has_services:
-        compilers = ["@io_bazel_rules_go//proto:go_grpc", "//bazel:pgv_plugin_go"]
+        compilers = ["@io_bazel_rules_go//proto:go_grpc", "@com_envoyproxy_protoc_gen_validate//bazel/go:pgv_plugin_go"]
 
     # Because RBAC proro depends on googleapis syntax.proto and checked.proto,
     # which share the same go proto library, it causes duplicative dependencies.


### PR DESCRIPTION
com_envoyproxy_protoc_gen_validate provides the go_proto_compiler with this exact same configuration