### PR TITLE
Convert invalid :ref: into regular link in orca_load_report.proto.

### DIFF
--- a/xds/data/orca/v3/orca_load_report.proto
+++ b/xds/data/orca/v3/orca_load_report.proto
@@ -10,7 +10,7 @@ option go_package = "github.com/cncf/xds/go/xds/data/orca/v3";
 import "validate/validate.proto";
 
 // See section `ORCA load report format` of the design document in
-// :ref:`https://github.com/envoyproxy/envoy/issues/6614`.
+// https://github.com/envoyproxy/envoy/issues/6614.
 
 message OrcaLoadReport {
   // CPU utilization expressed as a fraction of available CPU resources. This


### PR DESCRIPTION
This fixes Envoy doc generation error:

```
/tmp/tmp9o4nzftf/generated/rst/xds/data/orca/v3/orca_load_report.proto.rst:7: WARNING: undefined label: 'https://github.com/envoyproxy/envoy/issues/6614'
```

According to https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#external-links html links don't need any extra markup.