### PR TITLE
xRFC TP3: Error Propagation

### DIFF
--- a/proposals/TP3-xds-error-propagation.md
+++ b/proposals/TP3-xds-error-propagation.md
@@ -11,13 +11,13 @@ This proposal introduces enhancements to the [xDS transport protocol](https://ww
 
 The objective of this proposal is to suggest a way for clients to receive feedback from xDS Management Servers in case of partial/drastic failures without closing any streams or connections.
 
-This proposal includes a new field for each subscribed Resource, called `ResourceError`. This field will provide detailed information for resource specific issues. The client must use this additional field to obtain notification for resources the xDS Management server couldn’t procure and provide necessary notification to the application. 
+This proposal includes a new field for each subscribed Resource, called `ResourceError` which will provide detailed information for resource specific issues. The client must use this additional field to obtain notification for resources the xDS Management server couldn’t procure and provide necessary notification to the application. 
 
 ## Background
 
-A frequent use case for xDS involves client subscription to multiple resources from the xDS management server. Currently, if the xDS management server cannot provide a subset of these resources, the client experiences a complete loss of visibility. This can occur for various reasons, including but not limited to potential permission issues. This lack of granularity in the response can pose significant operational challenges. 
+A frequent use case for xDS involves client subscription to multiple resources from the management server. Currently, if the xDS management server cannot provide a subset of these resources, the client experiences a complete loss of visibility. This can occur for various reasons, including but not limited to potential permission issues. This lack of granularity in the response can pose significant operational challenges for general client observability or debugging. 
 
-The xDS protocol does have a way for xDS clients to NACK responses back from the xDS Management server. The NACK response also contains an `error_detail` field which the Management Server can use to extract further information about the rejection. But this NACK’ing mechanism is restricted to the client i.e. there is no way for Management Server to actually convey a notification(Ex: unavailability, permission issues etc) regarding some or all the resource requests that are being subscribed by the client. This eventually leads to the client timeouts which, although it conveys an error back to the application, it misses the actual context for the issue. In most cases the xDS Management Servers might not even be accessible for the applications to debug these issues without escalation. 
+The xDS protocol does have a way for xDS clients to NACK responses back from the xDS Management server. The NACK response also contains an `error_detail` field which the Management Server can use to extract further information about the rejection. But this NACK’ing mechanism is restricted to the client i.e. there is no way for Management Server to actually convey a notification(Ex: unavailability, permission issues etc) regarding some or all the resource requests that are being subscribed by the client. This eventually leads to the client timeouts which, although it conveys an error back to the application, it misses the actual context for the issue. In most cases the xDS Management Servers might not even be accessible for the client applications to debug these issues without escalation. 
 
 ### Related Proposals:
 
@@ -90,7 +90,7 @@ The major alternative to this proposal is to use Wrapped Resources by using Reso
 
 ### Wrapped Resources
 
- xDS resource containers are the default protos used for the Incremental xDS protocol and it's usage in SoTW is controlled via the client feature `xds.config.supports-resource-in-sotw`. 
+xDS resource containers are the default protos used for the Incremental xDS protocol and it's usage in SoTW is controlled via the client feature `xds.config.supports-resource-in-sotw`. 
 
 In this proposal the error information is directly passed as part of the resource field in the Resource Container, using the artifact that the field is a protobuf.Any. This enables us to designate the resource as either a `ResourceError` if the xDS management server encountered problems, or as the actual `Resource` if no errors occurred. 
 

--- a/proposals/TP3-xds-error-propagation.md
+++ b/proposals/TP3-xds-error-propagation.md
@@ -11,7 +11,7 @@ This proposal introduces a mechanism for the xDS control plane to communicate er
 
 The objective of this proposal is to suggest a way for clients to receive feedback from xDS Management Servers in case of partial/drastic failures without closing any streams or connections.
 
-This proposal includes a new field for each subscribed Resource, called `ResourceError` which will provide detailed information for resource specific issues. The client must use this additional field to obtain notification for resources the xDS Management server couldn’t procure and provide necessary notification to the application. 
+This proposal includes a new field for each subscribed Resource, called `ResourceError` which will provide detailed information for resource specific issues. The client may use this additional field to obtain notification for resources the xDS Management server couldn’t procure and provide necessary notification to the application. 
 
 ## Background
 

--- a/proposals/TP3-xds-error-propagation.md
+++ b/proposals/TP3-xds-error-propagation.md
@@ -21,7 +21,7 @@ The xDS protocol does have a way for xDS clients to NACK responses back from the
 
 ### Related Proposals:
 
-N/A
+* [TP1-xds-transport-next.md](https://github.com/cncf/xds/blob/main/proposals/TP1-xds-transport-next.md)
 
 ## Proposal
 

--- a/proposals/TP3-xds-error-propagation.md
+++ b/proposals/TP3-xds-error-propagation.md
@@ -1,6 +1,6 @@
 TP3: xds-error-propagation
 ----
-* Author(s): Anirudh Ramachandra
+* Author(s): anicr7
 * Approvers: htuch, markdroth, adisuissa
 * Implemented in: <xDS client, ...>
 * Last updated: 2024-10-25
@@ -15,7 +15,7 @@ This proposal includes a new field for each subscribed Resource, called `Resourc
 
 ## Background
 
-A frequent use case for xDS involves client subscription to multiple resources from the xDS management server. Currently, if the xDS management server cannot provide a subset of these resources, the client experiences a complete loss of visibility. This can occur for various reasons, including but not limited to potential permission issues. This lack of granularity in the response can lead to significant operational challenges. 
+A frequent use case for xDS involves client subscription to multiple resources from the xDS management server. Currently, if the xDS management server cannot provide a subset of these resources, the client experiences a complete loss of visibility. This can occur for various reasons, including but not limited to potential permission issues. This lack of granularity in the response can pose significant operational challenges. 
 
 The xDS protocol does have a way for xDS clients to NACK responses back from the xDS Management server. The NACK response also contains an `error_detail` field which the Management Server can use to extract further information about the rejection. But this NACK’ing mechanism is restricted to the client i.e. there is no way for Management Server to actually convey a notification(Ex: unavailability, permission issues etc) regarding some or all the resource requests that are being subscribed by the client. This eventually leads to the client timeouts which, although it conveys an error back to the application, it misses the actual context for the issue. In most cases the xDS Management Servers might not even be accessible for the applications to debug these issues without escalation. 
 
@@ -90,7 +90,7 @@ The major alternative to this proposal is to use Wrapped Resources by using Reso
 
 ### Wrapped Resources
 
- xDS resource containers are the default protos used for the Incremental xDS protocol and is controlled via the client feature `xds.config.supports-resource-in-sotw` for SoTW. 
+ xDS resource containers are the default protos used for the Incremental xDS protocol and it's usage in SoTW is controlled via the client feature `xds.config.supports-resource-in-sotw`. 
 
 In this proposal the error information is directly passed as part of the resource field in the Resource Container, using the artifact that the field is a protobuf.Any. This enables us to designate the resource as either a `ResourceError` if the xDS management server encountered problems, or as the actual `Resource` if no errors occurred. 
 

--- a/proposals/TP3-xds-error-propagation.md
+++ b/proposals/TP3-xds-error-propagation.md
@@ -1,0 +1,135 @@
+TP3: xds-error-propagation
+----
+* Author(s): anramach
+* Approvers: htuch, markdroth, adisuissa
+* Implemented in: <xDS client, ...>
+* Last updated: [YYYY-MM-DD]
+
+## Abstract
+
+This proposal introduces enhancements to the [xDS transport protocol](https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol), focusing on improved debugging and observability. Specifically, it outlines a mechanism for the control plane to communicate error information directly to xDS clients.
+
+The objective of this proposal is to suggest a way for clients to receive feedback from xDS Management Servers in case of partial/drastic failures without closing any streams or connections.
+
+This proposal includes a new field for each subscribed Resource, called ResourceError. This field will provide detailed information resource specific issues. The client must use this additional field to obtain notification for resources the xDS Management server couldn’t procure and provide necessary notification to the user. 
+
+
+## Background
+
+A frequent use case for xDS involves client subscription to multiple resources from the xDS management server. Currently, if the xDS management server cannot provide a subset of these resources, the client experiences a complete loss of visibility. This can occur for various reasons, including but not limited to potential permission issues. This lack of granularity in the response can lead to significant operational challenges. 
+
+The xDS protocol does have a way for Envoy/gRPC to NACK responses back from the xDS Management server. The NACK response also contains an error_detail which the Management Server can use to extract further information about the rejection. But this NACK’ing mechanism is restricted to the client i.e. there is no way for Management Server to actually convey a notification(Ex: unavailability, permission issues etc) regarding some or all the resource requests that are being subscribed by the client.
+
+This eventually leads to the client timeouts which, although it conveys an error back to the application, it misses the actual context for the issue. In most cases the xDS Management Servers might not even be accessible for the applications to debug these issues without escalation. 
+
+
+
+### Related Proposals:
+
+N/A
+
+## Proposal
+
+The proposal introduces two new fields to the DiscoveryResponse proto. The first, `resource_errors`, will detail Resource-specific errors and be included in both SotW and Incremental xDS protocols. The second, `removed_resources`, will specifically identify resources that no longer exist, addressing a current gap in the SotW protocol's signaling capabilities. 
+
+```textproto
+// New Proto Message
+// Contains detailed error detail for a single resource
+message ResourceError {
+ ResourceName resource_name = 1;
+
+ google.rpc.Status error_detail = 2;
+}
+
+message DiscoveryResponse {
+
+// The version of the response data.
+string version_info = 1;
+
+….
+…
+
+
+ // The control plane instance that sent the response.
+  config.core.v3.ControlPlane control_plane = 6;
+
+// NEW_FIELD
+// An optional repeated list of error details that the control plane 
+// can provide to notify the client of issues for the resources that 
+// are subscribed.
+// This allows the xDS management server to provide optional 
+// notifications in case of unavailability, permissions errors 
+// without the client having to wait for the `config fetch` timeout.
+repeated ResourceError resource_errors = N;
+
+// NEW FIELD
+// For non-existing resources.
+repeated ResourceName removed_resources = N;
+}
+
+message DeltaDiscoveryResponse {
+  …
+
+  // NEW FIELD
+  repeated ResourceError resource_errors = N;
+}
+```
+
+### Protocol Behavior
+The client must use this additional field to obtain notification for resources the xDS Management server couldn’t procure. The xDS client should cancel any resource timers once this message is received and convey the error message to the application. 
+
+With the addition of this field, when a client receives an explicit error or does-not-exist indicator from the management server, it should react the same way it would have if its does-not-exist timer fired. 
+
+The xDS Management server is only expected to return the error message once rather than throughout for future responses. The client is expected to remember the error message until either a new error message is returned or the resource is returned. 
+
+### Wildcard Resources
+
+It is possible to subscribe to all resources by a client using a wildcard or “” resource name.The control plane in this case can provide error details for two different use cases. One when the issue is with the glob itself or later on when the issue is specific to individual resources. 
+
+For errors associated with wildcard(“” for legacy or “*”) and for xDS-TP glob collections; the control plane error_details resource name will match the relevant wildcard request(“” or “*” or xDS-TP glob collections). This can be used by the control plane to indicate an error with the collection as a whole.
+For errors associated with specific individual resources that match the glob,
+The resource name should be the specific resource name associated with the error 
+OR
+The control could just not use this mechanism for wildcard subscriptions, because if the client doesn't have permission to access a resource, then it probably shouldn't be considered to match the wildcard subscription to begin with.
+
+
+## Rationale
+
+This section documents limitations and design alternatives that were considered.
+
+### Wrapped Resources
+
+The major alternative to this proposal is to use Wrapped Resources. 
+
+xDS supports passing resources via a wrapped Resource Container. This is the default for the Incremental xDS protocol and is controlled via the client feature xds.config.supports-resource-in-sotw for SoTW. 
+
+In this proposal the error information is directly passed as part of the resource field in the Resource Container, using the artifact that the field currently is protobuf.Any. This enables us to designate the resource as either a `ResourceError` if the xDS management server encountered problems, or as the actual `Resource` if no errors occurred. 
+
+#### Backward Compatibility
+
+To avoid possible confusion with this behavior, it will be protected with a client feature similar to  supports-resource-in-sotw  called supports-resource-error-unwrapping. 
+
+Note: This should also be documented here: https://www.envoyproxy.io/docs/envoy/latest/api/client_features#currently-defined-client-features
+
+
+#### Why not this approach?
+
+This approach has two major drawbacks compared to the chosen approach:
+
+This alternative would not work for non-wrapped resources
+It introduces a backwards compatibility issue, which adding a new field wouldn’t have as clients would just ignore them. 
+
+
+## Implementation
+
+This will probably be implemented in gRPC before Envoy
+
+## Open issues (if applicable)
+
+### Possible improvements to NACKs
+
+Currently, the xDS protocol does not provide a clear mechanism for partial NACKs i.e. a way for the client to accept some of the resources that are sent by the management server.
+
+There have been few discussions of this behavior mainly https://github.com/grpc/proposal/blob/master/A46-xds-nack-semantics-improvement.md and https://github.com/envoyproxy/envoy/issues/32880. Currently clients have a general behavior of accepting certain resources even if they are NACKed but this information is not clearly communicated via the xDS protocol.
+
+Eventually using a similar field as this proposal gives us an opportunity to fix this issue in xDS for both the client and the management server, as the DiscoveryRequest could also use the new message `ResourceError` to provide explicit details about the resources not accepted. 

--- a/proposals/TP3-xds-error-propagation.md
+++ b/proposals/TP3-xds-error-propagation.md
@@ -22,7 +22,7 @@ Note that while the incremental protocol variants can explicitly indicate to the
 
 ### Related Proposals:
 
-* [TP1-xds-transport-next.md](https://github.com/cncf/xds/blob/main/proposals/TP1-xds-transport-next.md)
+* [TP1-xds-transport-next.md](TP1-xds-transport-next.md)
 
 ## Proposal
 
@@ -72,16 +72,16 @@ message DeltaDiscoveryResponse {
 ```
 
 ### Protocol Behavior
-All client are eventually expected to use this additional field to obtain notification for resources the xDS Management server couldn’t procure. The xDS client should cancel any resource timers once this message is received and convey the error message to the application(i.e. fail a data plane request with a useful error message instead of a timeout). With the addition of this field, when a client receives an explicit error or does-not-exist indicator from the management server, it should react the same way it would have if its does-not-exist timer fired. 
+Clients that support this mechanism will use this additional field to obtain notification for resources the xDS Management server couldn’t procure. The xDS client should cancel any resource timers once this message is received and convey the error message to the application(i.e. fail a data plane request with a useful error message instead of a timeout). With the addition of this field, when a client receives an explicit error or does-not-exist indicator from the management server, it should react the same way it would have if its does-not-exist timer fired. 
 
 The xDS Management server is only expected to return the error message once rather than throughout for future responses. The client is expected to remember the error message until either a new error message is returned or the resource is returned. This includes LDS and CDS where the control plane is required to send every subscribed 
 resource in every response. 
 
 As the clients don't look at this field right now, the xDS management server must assume the responses remain valid for older clients for backward compatibility. For example, in the SotW variant, LDS and CDS are required to send all subscribed resources in every response, which means that if a control plane wants to send an update for one of these resource types that indicates an error with a particular resource, it must still include all of the subscribed resources that it can return in that response.
 
-### Wildcard Resources
+### Wildcard Resources and Glob Collections
 
-It is possible to subscribe to all resources by a client using a wildcard or "" resource name or a [global collection](https://github.com/cncf/xds/blob/main/proposals/TP1-xds-transport-next.md). The control plane in this case can provide error details for two different use cases. One when the issue is with the glob itself or later on when the issue is specific to individual resources. 
+For legacy wildcard subscriptions or [glob collections](TP1-xds-transport-next.md#glob), the control plane is responsible for deciding which resources are included in the subscription. The control plane in this case can provide error details for two different use cases. One when the issue is with the glob itself or later on when the issue is specific to individual resources. 
 
 1. For errors associated with wildcard("" for legacy or `*`) and for xDS-TP glob collections; the control plane `error_details` resource name will match the relevant wildcard request("" or `*` or xDS-TP glob collections). This can be used by the control plane to indicate an error with the collection as a whole.
 2. For errors associated with specific individual resources that match the glob,

--- a/proposals/TP3-xds-error-propagation.md
+++ b/proposals/TP3-xds-error-propagation.md
@@ -112,11 +112,3 @@ This approach has two major drawbacks compared to the chosen approach:
 This will probably be implemented in gRPC before Envoy.
 
 ## Open issues (if applicable)
-
-### Possible improvements to NACKs
-
-Currently, the xDS protocol does not provide a clear mechanism for partial NACKs i.e. a way for the client to accept some of the resources that are sent by the management server.
-
-There have been few discussions of this behavior mainly in https://github.com/grpc/proposal/blob/master/A46-xds-nack-semantics-improvement.md and https://github.com/envoyproxy/envoy/issues/32880. Currently clients have a general behavior of accepting certain resources even if they are NACKed but this information is not clearly communicated via the xDS protocol.
-
-Eventually using a similar field as this proposal gives us an opportunity to fix this issue in xDS for both the client and the management server, as the DiscoveryRequest could also use the new message `ResourceError` to provide explicit details about the resources not accepted. 

--- a/proposals/TP3-xds-error-propagation.md
+++ b/proposals/TP3-xds-error-propagation.md
@@ -78,8 +78,9 @@ service ClientStatusDiscoveryService {
     ...
 
     // NEW FIELD
-    // Should be treated basically the same as `CLIENT_NACKED`.
-    // Provides the previously cached version of the resource but also indicates a server error that was recieved using resource_errors field.
+    // Client received an error from the control plane. The attached config
+    // dump is the most recent accepted one. If no config is accepted yet,
+    // the attached config dump will be empty.
     CLIENT_RECEIVED_ERROR = 4;
   }
 }

--- a/proposals/TP3-xds-error-propagation.md
+++ b/proposals/TP3-xds-error-propagation.md
@@ -77,9 +77,9 @@ The xDS Management server is only expected to return the error message once rath
 
 ### Wildcard Resources
 
-It is possible to subscribe to all resources by a client using a wildcard or "" resource name. The control plane in this case can provide error details for two different use cases. One when the issue is with the glob itself or later on when the issue is specific to individual resources. 
+It is possible to subscribe to all resources by a client using a wildcard or "" resource name or a [global collection](https://github.com/cncf/xds/blob/main/proposals/TP1-xds-transport-next.md). The control plane in this case can provide error details for two different use cases. One when the issue is with the glob itself or later on when the issue is specific to individual resources. 
 
-1. For errors associated with wildcard("" for legacy or "*") and for xDS-TP glob collections; the control plane `error_details` resource name will match the relevant wildcard request("" or "*" or xDS-TP glob collections). This can be used by the control plane to indicate an error with the collection as a whole.
+1. For errors associated with wildcard("" for legacy or `*`) and for xDS-TP glob collections; the control plane `error_details` resource name will match the relevant wildcard request("" or `*` or xDS-TP glob collections). This can be used by the control plane to indicate an error with the collection as a whole.
 2. For errors associated with specific individual resources that match the glob,
     * The resource name should be the specific resource name associated with the error  OR
     * The control could just not use this mechanism for wildcard subscriptions, because if the client doesn't have permission to access a resource, then it probably shouldn't be considered to match the wildcard subscription to begin with.

--- a/proposals/TP3-xds-error-propagation.md
+++ b/proposals/TP3-xds-error-propagation.md
@@ -72,9 +72,12 @@ message DeltaDiscoveryResponse {
 ```
 
 ### Protocol Behavior
-The client must use this additional field to obtain notification for resources the xDS Management server couldn’t procure. The xDS client should cancel any resource timers once this message is received and convey the error message to the application. With the addition of this field, when a client receives an explicit error or does-not-exist indicator from the management server, it should react the same way it would have if its does-not-exist timer fired. 
+All client are eventually expected to use this additional field to obtain notification for resources the xDS Management server couldn’t procure. The xDS client should cancel any resource timers once this message is received and convey the error message to the application(i.e. fail a data plane request with a useful error message instead of a timeout). With the addition of this field, when a client receives an explicit error or does-not-exist indicator from the management server, it should react the same way it would have if its does-not-exist timer fired. 
 
-The xDS Management server is only expected to return the error message once rather than throughout for future responses. The client is expected to remember the error message until either a new error message is returned or the resource is returned. This includes LDS and CDS where the control plane is required to send every subscribed resource in every response. 
+The xDS Management server is only expected to return the error message once rather than throughout for future responses. The client is expected to remember the error message until either a new error message is returned or the resource is returned. This includes LDS and CDS where the control plane is required to send every subscribed 
+resource in every response. 
+
+As currently the clients don't look at this field right now, the xDS management server must assume the responses remain valid for older clients. For example, in the SotW variant, LDS and CDS are required to send all subscribed resources in every response, which means that if a control plane wants to send an update for one of these resource types that indicates an error with a particular resource, it must still include all of the subscribed resources that it can return in that response.
 
 ### Wildcard Resources
 

--- a/proposals/TP3-xds-error-propagation.md
+++ b/proposals/TP3-xds-error-propagation.md
@@ -78,18 +78,16 @@ Clients that support this mechanism will use this additional field to obtain err
 Note that an error with status code NOT_FOUND will be interpreted to mean that the resource does not exist. The client should handle this case exactly the same way that it would if the does-not-exist timer fired or if it receives removed_resources or removed_resource_names in the incremental protocol variant.
 
 The xDS Management server is only expected to return the error message once rather than throughout for future responses. The client is expected to remember the error message until either a new error message is returned or the resource is returned. This includes LDS and CDS where the control plane is required to send every subscribed 
-resource in every response. 
+resource in every response. The set of resources with errors and the set of valid resources must not intersect. 
 
-As the clients don't look at this field right now, the xDS management server must assume the responses remain valid for older clients for backward compatibility. For example, in the SotW variant, LDS and CDS are required to send all subscribed resources in every response, which means that if a control plane wants to send an update for one of these resource types that indicates an error with a particular resource, it must still include all of the subscribed resources that it can return in that response.
+As the clients don't look at this field right now, the xDS management server must assume the responses remain valid for older clients for backward compatibility. For example, in the SotW variant, LDS and CDS are required to send all subscribed resources in every response, which means that if a control plane wants to send an update for one of these resource types that indicates an error with a particular resource, it must still include all of the subscribed resources that it can return in that response. 
 
 ### Wildcard Subscriptions and Glob Collections
 
 For [glob collections](TP1-xds-transport-next.md#glob), the control plane is responsible for deciding which resources are included in the subscription. The control plane in this case can provide error details for two different use cases. One when the issue is with the glob itself or later on when the issue is specific to individual resources. 
 
 1. For errors associated with xDS-TP glob collections; the control plane `error_details` resource name will match the relevant xDS-TP glob collection. This can be used by the control plane to indicate an error with the collection as a whole.
-2. For errors associated with specific individual resources that match the glob,
-    * The resource name should be the specific resource name associated with the error  OR
-    * The control could just not use this mechanism for wildcard subscriptions, because if the client doesn't have permission to access a resource, then it probably shouldn't be considered to match the wildcard subscription to begin with.
+2. For errors associated with specific individual resources that match the glob; the resource name should be the specific resource name associated with the error.
 
 This mechanism currently doesn't support wildcard subscriptions at the moment, though it can be modified in the future if needed. 
 
@@ -101,7 +99,7 @@ The major alternative to this proposal is to use Wrapped Resources by using Reso
 
 xDS resource containers are the default protos used for the Incremental xDS protocol and it's usage in SoTW is controlled via the client feature `xds.config.supports-resource-in-sotw`. 
 
-In this proposal the error information is directly passed as part of the resource field in the Resource Container, using the artifact that the field is a protobuf.Any. This enables us to designate the resource as either a `ResourceError` if the xDS management server encountered problems, or as the actual `Resource` if no errors occurred. 
+In this proposal the error information is directly passed as part of the resource field in the Resource Container, using the artifact that the field is a protobuf.Any. This enables us to designate the resource as either a `google.rpc.Status` if the xDS management server encountered problems, or as the actual `Resource` if no errors occurred. 
 
 #### Backward Compatibility
 

--- a/proposals/TP3-xds-error-propagation.md
+++ b/proposals/TP3-xds-error-propagation.md
@@ -71,10 +71,9 @@ message DeltaDiscoveryResponse {
 ### Protocol Behavior
 Clients that support this mechanism will use this additional field to obtain error information for resources that the xDS server couldn’t provide. When this message is received, the xDS client should cancel any resource timers for the indicated resource. The client should then handle the error based on the status code, as follows (using RFC-2119 terminology):
 
-The following codes will be interpretted by clients as transient failures, meaning that the client MUST continue to use previously cached versions of the resource if it has them: UNAVAILABLE, INTERNAL, UNKNOWN.
-
-The following codes will be interpretted by clients as data errors, which the client MAY handle by dropping any previously cached resource: NOT_FOUND, PERMISSION_DENIED
-The behavior for any other status code is undefined. Data planes SHOULD treat these as transient failures, but future xRFCs may impose additional semantics on them.
+  * The following codes will be interpretted by clients as transient failures, meaning that the client MUST continue to use previously cached versions of the resource if it has them: UNAVAILABLE, INTERNAL, UNKNOWN.
+  * The following codes will be interpretted by clients as data errors, which the client MAY handle by dropping any previously cached resource: NOT_FOUND, PERMISSION_DENIED
+  * The behavior for any other status code is undefined. Data planes SHOULD treat these as transient failures, but future xRFCs may impose additional semantics on them.
 Note that an error with status code NOT_FOUND will be interpreted to mean that the resource does not exist. The client should handle this case exactly the same way that it would if the does-not-exist timer fired or if it receives removed_resources or removed_resource_names in the incremental protocol variant.
 
 The xDS Management server is only expected to return the error message once rather than throughout for future responses. The client is expected to remember the error message until either a new error message is returned or the resource is returned. This includes LDS and CDS where the control plane is required to send every subscribed 

--- a/proposals/TP3-xds-error-propagation.md
+++ b/proposals/TP3-xds-error-propagation.md
@@ -69,11 +69,12 @@ message DeltaDiscoveryResponse {
 ```
 
 ### Protocol Behavior
-Clients that support this mechanism will use this additional field to obtain error information for resources that the xDS server couldn’t provide. When this message is received, the xDS client should cancel any resource timers for the indicated resource. The client should then handle the error based on the status code, as follows (using RFC-2119 terminology):
+Clients that support this mechanism will use this additional field to obtain error information for resources that the xDS server couldn’t provide. When this message is received, the xDS client should cancel any resource timers for the indicated resource. The client should then handle the error based on the status code, as follows (using [RFC-2119](https://datatracker.ietf.org/doc/html/rfc2119) terminology):
 
   * The following codes will be interpretted by clients as transient failures, meaning that the client MUST continue to use previously cached versions of the resource if it has them: UNAVAILABLE, INTERNAL, UNKNOWN.
   * The following codes will be interpretted by clients as data errors, which the client MAY handle by dropping any previously cached resource: NOT_FOUND, PERMISSION_DENIED
   * The behavior for any other status code is undefined. Data planes SHOULD treat these as transient failures, but future xRFCs may impose additional semantics on them.
+
 Note that an error with status code NOT_FOUND will be interpreted to mean that the resource does not exist. The client should handle this case exactly the same way that it would if the does-not-exist timer fired or if it receives removed_resources or removed_resource_names in the incremental protocol variant.
 
 The xDS Management server is only expected to return the error message once rather than throughout for future responses. The client is expected to remember the error message until either a new error message is returned or the resource is returned. This includes LDS and CDS where the control plane is required to send every subscribed 

--- a/proposals/TP3-xds-error-propagation.md
+++ b/proposals/TP3-xds-error-propagation.md
@@ -77,7 +77,7 @@ All client are eventually expected to use this additional field to obtain notifi
 The xDS Management server is only expected to return the error message once rather than throughout for future responses. The client is expected to remember the error message until either a new error message is returned or the resource is returned. This includes LDS and CDS where the control plane is required to send every subscribed 
 resource in every response. 
 
-As currently the clients don't look at this field right now, the xDS management server must assume the responses remain valid for older clients. For example, in the SotW variant, LDS and CDS are required to send all subscribed resources in every response, which means that if a control plane wants to send an update for one of these resource types that indicates an error with a particular resource, it must still include all of the subscribed resources that it can return in that response.
+As the clients don't look at this field right now, the xDS management server must assume the responses remain valid for older clients for backward compatibility. For example, in the SotW variant, LDS and CDS are required to send all subscribed resources in every response, which means that if a control plane wants to send an update for one of these resource types that indicates an error with a particular resource, it must still include all of the subscribed resources that it can return in that response.
 
 ### Wildcard Resources
 

--- a/proposals/TP3-xds-error-propagation.md
+++ b/proposals/TP3-xds-error-propagation.md
@@ -84,12 +84,14 @@ As the clients don't look at this field right now, the xDS management server mus
 
 ### Wildcard Subscriptions and Glob Collections
 
-For legacy wildcard subscriptions or [glob collections](TP1-xds-transport-next.md#glob), the control plane is responsible for deciding which resources are included in the subscription. The control plane in this case can provide error details for two different use cases. One when the issue is with the glob itself or later on when the issue is specific to individual resources. 
+For [glob collections](TP1-xds-transport-next.md#glob), the control plane is responsible for deciding which resources are included in the subscription. The control plane in this case can provide error details for two different use cases. One when the issue is with the glob itself or later on when the issue is specific to individual resources. 
 
-1. For errors associated with wildcard("" for legacy or `*`) and for xDS-TP glob collections; the control plane `error_details` resource name will match the relevant wildcard request("" or `*` or xDS-TP glob collections). This can be used by the control plane to indicate an error with the collection as a whole.
+1. For errors associated with xDS-TP glob collections; the control plane `error_details` resource name will match the relevant xDS-TP glob collection. This can be used by the control plane to indicate an error with the collection as a whole.
 2. For errors associated with specific individual resources that match the glob,
     * The resource name should be the specific resource name associated with the error  OR
     * The control could just not use this mechanism for wildcard subscriptions, because if the client doesn't have permission to access a resource, then it probably shouldn't be considered to match the wildcard subscription to begin with.
+
+This mechanism currently doesn't support wildcard subscriptions at the moment, though it can be modified in the future if needed. 
 
 ## Rationale
 

--- a/proposals/TP3-xds-error-propagation.md
+++ b/proposals/TP3-xds-error-propagation.md
@@ -1,7 +1,7 @@
 TP3: xds-error-propagation
 ----
 * Author(s): anicr7
-* Approvers: htuch, markdroth, adisuissa
+* Approvers: markdroth, adisuissa
 * Implemented in: <xDS client, ...>
 * Last updated: 2024-10-25
 


### PR DESCRIPTION
Proposal for the xDS error propagation which allows xDS management servers to provide additional information to the clients in case of errors like permission errors or resource being missing.

cc: @markdroth, @adisuissa, @htuch 