### PR TITLE
Use cc_test from rules_cc instead of native.cc_test

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,6 +11,7 @@ bazel_dep(name = "grpc", version = "1.68.0", repo_name = "com_github_grpc_grpc")
 bazel_dep(name = "protobuf", version = "29.3", repo_name = "com_google_protobuf")
 bazel_dep(name = "protoc-gen-validate", version = "1.2.1.bcr.1", repo_name = "com_envoyproxy_protoc_gen_validate")
 bazel_dep(name = "re2", version = "2024-07-02", repo_name = "com_googlesource_code_re2")
+bazel_dep(name = "rules_cc", version = "0.0.17")
 bazel_dep(name = "rules_go", version = "0.53.0", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "rules_python", version = "1.6.3")
 

--- a/bazel/api_build_system.bzl
+++ b/bazel/api_build_system.bzl
@@ -4,6 +4,7 @@ load("@com_github_grpc_grpc//bazel:python_rules.bzl", _py_proto_library = "py_pr
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_grpc_library", "go_proto_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load(
     "//bazel:external_proto_deps.bzl",
     "EXTERNAL_PROTO_CC_BAZEL_DEP_MAP",
@@ -136,7 +137,7 @@ def xds_proto_package(
     )
 
 def xds_cc_test(name, **kwargs):
-    native.cc_test(
+    cc_test(
         name = name,
         **kwargs
     )
@@ -157,4 +158,3 @@ def udpa_cc_test(name, **kwargs):
 
 def udpa_go_test(name, **kwargs):
     xds_go_test(name, **kwargs)
-

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -42,6 +42,10 @@ def xds_api_dependencies():
         "rules_proto",
         locations = REPOSITORY_LOCATIONS,
     )
+    xds_http_archive(
+        "rules_cc",
+        locations = REPOSITORY_LOCATIONS,
+    )
 
 # Old name for backward compatibility.
 # TODO(roth): Remove once all callers are updated to use the new name.

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -43,6 +43,11 @@ REPOSITORY_LOCATIONS = dict(
             "https://github.com/bazelbuild/rules_go/releases/download/v0.53.0/rules_go-v0.53.0.zip",
         ],
     ),
+    rules_cc = dict(
+        sha256 = "abc605dd850f813bb37004b77db20106a19311a96b2da1c92b789da529d28fe1",
+        strip_prefix = "rules_cc-0.0.17",
+        urls = ["https://github.com/bazelbuild/rules_cc/archive/refs/tags/0.0.17.tar.gz"],
+    ),
     rules_proto = dict(
         sha256 = "14a225870ab4e91869652cfd69ef2028277fc1dc4910d65d353b62d6e0ae21f4",
         strip_prefix = "rules_proto-7.1.0",


### PR DESCRIPTION
#### Description

Use cc_test from rules_cc instead of native.cc_test to be compatible with Bazel 9