### PR TITLE
xds-core: mark CIDR as stable

### DIFF
--- a/go/xds/core/v3/cidr.pb.go
+++ b/go/xds/core/v3/cidr.pb.go
@@ -84,7 +84,7 @@ const file_xds_core_v3_cidr_proto_rawDesc = "" +
 	"\tCidrRange\x12.\n" +
 	"\x0eaddress_prefix\x18\x01 \x01(\tB\a\xfaB\x04r\x02\x10\x01R\raddressPrefix\x12E\n" +
 	"\n" +
-	"prefix_len\x18\x02 \x01(\v2\x1c.google.protobuf.UInt32ValueB\b\xfaB\x05*\x03\x18\x80\x01R\tprefixLenBV\xd2Ƥ\xe1\x06\x02\b\x01\n" +
+	"prefix_len\x18\x02 \x01(\v2\x1c.google.protobuf.UInt32ValueB\b\xfaB\x05*\x03\x18\x80\x01R\tprefixLenBN\n" +
 	"\x16com.github.xds.core.v3B\x0eCidrRangeProtoP\x01Z\"github.com/cncf/xds/go/xds/core/v3b\x06proto3"
 
 var (

--- a/python/xds/core/v3/cidr_pb2.py
+++ b/python/xds/core/v3/cidr_pb2.py
@@ -27,14 +27,14 @@ from google.protobuf import wrappers_pb2 as google_dot_protobuf_dot_wrappers__pb
 from validate import validate_pb2 as validate_dot_validate__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x16xds/core/v3/cidr.proto\x12\x0bxds.core.v3\x1a\x1fxds/annotations/v3/status.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a\x17validate/validate.proto\"h\n\tCidrRange\x12\x1f\n\x0e\x61\x64\x64ress_prefix\x18\x01 \x01(\tB\x07\xfa\x42\x04r\x02\x10\x01\x12:\n\nprefix_len\x18\x02 \x01(\x0b\x32\x1c.google.protobuf.UInt32ValueB\x08\xfa\x42\x05*\x03\x18\x80\x01\x42V\n\x16\x63om.github.xds.core.v3B\x0e\x43idrRangeProtoP\x01Z\"github.com/cncf/xds/go/xds/core/v3\xd2\xc6\xa4\xe1\x06\x02\x08\x01\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x16xds/core/v3/cidr.proto\x12\x0bxds.core.v3\x1a\x1fxds/annotations/v3/status.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a\x17validate/validate.proto\"h\n\tCidrRange\x12\x1f\n\x0e\x61\x64\x64ress_prefix\x18\x01 \x01(\tB\x07\xfa\x42\x04r\x02\x10\x01\x12:\n\nprefix_len\x18\x02 \x01(\x0b\x32\x1c.google.protobuf.UInt32ValueB\x08\xfa\x42\x05*\x03\x18\x80\x01\x42N\n\x16\x63om.github.xds.core.v3B\x0e\x43idrRangeProtoP\x01Z\"github.com/cncf/xds/go/xds/core/v3b\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'xds.core.v3.cidr_pb2', _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
-  _globals['DESCRIPTOR']._serialized_options = b'\n\026com.github.xds.core.v3B\016CidrRangeProtoP\001Z\"github.com/cncf/xds/go/xds/core/v3\322\306\244\341\006\002\010\001'
+  _globals['DESCRIPTOR']._serialized_options = b'\n\026com.github.xds.core.v3B\016CidrRangeProtoP\001Z\"github.com/cncf/xds/go/xds/core/v3'
   _globals['_CIDRRANGE'].fields_by_name['address_prefix']._loaded_options = None
   _globals['_CIDRRANGE'].fields_by_name['address_prefix']._serialized_options = b'\372B\004r\002\020\001'
   _globals['_CIDRRANGE'].fields_by_name['prefix_len']._loaded_options = None

--- a/xds/core/v3/cidr.proto
+++ b/xds/core/v3/cidr.proto
@@ -12,8 +12,6 @@ option java_multiple_files = true;
 option java_package = "com.github.xds.core.v3";
 option go_package = "github.com/cncf/xds/go/xds/core/v3";
 
-option (xds.annotations.v3.file_status).work_in_progress = true;
-
 // CidrRange specifies an IP Address and a prefix length to construct
 // the subnet mask for a `CIDR <https://tools.ietf.org/html/rfc4632>`_ range.
 message CidrRange {


### PR DESCRIPTION
removing the work-in-progress annotation to cidr.proto
the CidrRange seems to be used in a bunch of place notably in [Envoy RBAC](https://github.com/envoyproxy/envoy/blob/09603b06b93c4f9278a096ad5beb2780eaf263fe/api/envoy/config/rbac/v3/rbac.proto#L273).

issues for discussion: https://github.com/cncf/xds/issues/137
