### PR TITLE
Upgrade google.golang.org/grpc from v1.76.0 to v1.79.3 to address a critical authorization bypass vulnerability

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -6,7 +6,7 @@ require (
 	cel.dev/expr v0.25.1
 	github.com/envoyproxy/protoc-gen-validate v1.3.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20250804133106-a7a43d27e69b
-	google.golang.org/grpc v1.76.0
+	google.golang.org/grpc v1.79.3
 	google.golang.org/protobuf v1.36.10
 )
 


### PR DESCRIPTION
## Security Fix: HTTP/2 :path Header Authorization Bypass

Upgrade google.golang.org/grpc from v1.76.0 to v1.79.3 to address a critical authorization bypass vulnerability ([Github Official](https://github.com/grpc/grpc-go/security/advisories/GHSA-p77j-4mvh-x3m3)).

### Vulnerability Details

**Issue**: gRPC-Go servers prior to v1.79.3 accepted HTTP/2 requests with malformed `:path` pseudo-headers (missing leading slash), which could bypass path-based authorization interceptors.

**Impact**: 
- Affects gRPC servers using path-based authorization interceptors (including the official `google.golang.org/grpc/authz` package)
- Attackers could send raw HTTP/2 frames with non-canonical paths (e.g., `Service/Method` instead of `/Service/Method`)
- Authorization "deny" rules defined using canonical paths failed to match, allowing bypass if fallback "allow" rules existed

**Root Cause**: The gRPC server was too lenient in routing logic, accepting non-canonical paths but evaluating them against authorization policies that expected canonical paths.

### Fix

v1.79.3 ensures that any request with a `:path` that does not start with a leading slash is immediately rejected with a `codes.Unimplemented` error before reaching authorization interceptors.

